### PR TITLE
Append protocol name graphql

### DIFF
--- a/src/Imposter.php
+++ b/src/Imposter.php
@@ -15,6 +15,7 @@ class Imposter
     const PROTOCOL_HTTPS = 'https';
     const PROTOCOL_TCP = 'tcp';
     const PROTOCOL_SMTP = 'smtp';
+    const PROTOCOL_GRAPHQL = 'graphql';
 
     /**
      * The port to run the imposter on.


### PR DESCRIPTION
hi, @demyan112rv 

When using https://github.com/bashj79/mb-graphql and mounteban-api-php together, found out `mounteban-api-php` does not support `graphql` protocol. 

yes, `graphql` belongs to mountebank plugin, how about we just append the protocol name incase the user case mb-graphql + mountebank-api-php

Thank you for review!

regards
Mike