### PR TITLE
Upgrade to suport php 8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
 - 7.3
 - 7.4
 - 8.0
+- 8.1
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     }
   },
   "require": {
-    "php": ">=7.3 <8.1",
+    "php": ">=7.3 <=8.1",
     "ext-json": "*",
     "guzzlehttp/guzzle": ">=4.1.4"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c1603809b4238475cd6fd574b7f260a5",
+    "content-hash": "b9e96fdd20360b0146b5606d3516aec8",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -3604,7 +3604,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.3 <8.1",
+        "php": ">=7.3 <=8.1",
         "ext-json": "*"
     },
     "platform-dev": [],


### PR DESCRIPTION
hi, @demyan112rv 

Sorry, I don't know somehow the commit e3f6dc55860036056315db3ecba5354803a6dacf still in the PR. 
 
and can not remove it from this PR. 

Maybe you can create a PR for an upgrade to support PHP `8.1` ? 

thank you very much!